### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Note: This is a place to find and practice TDD Katas. Feel free to submit pull r
 
 -------------------
 
-###Kata - coming next [http://www.cyber-dojo.com/]
+### Kata - coming next [http://www.cyber-dojo.com/]
 
 #### Calc Stats:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
